### PR TITLE
Restore POSIX shell compatibility

### DIFF
--- a/npmrc
+++ b/npmrc
@@ -3,7 +3,7 @@
 NPMRC_STORE="${HOME}/.npmrcs";
 NPMRC="${HOME}/.npmrc";
 
-if [ "${1}" == "--help" -o "${1}" == "-h" ]; then
+if [ "${1}" = "--help" -o "${1}" = "-h" ]; then
   echo "npmrcs"
   echo ""
   echo "  Switch between different .npmrc files with ease and grace."


### PR DESCRIPTION
When `npmrc` is executed with `dash` it throws the following error:

```
./npmrc: 6: [: unexpected operator
```

This is due to 0c0b79f introducing string comparison using double equal signs which [doesn’t work in POSIX shells](http://stackoverflow.com/questions/1089813/bash-dash-and-string-comparison). This commit restores POSIX shell compatibility by using single equals signs.
