### PR TITLE
Add feature: npmrc --registry [TLD]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: node_js
+node_js: '0.10'

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 const test    = require('tape')
     , path    = require('path')
+    , os      = require('os')
     , fs      = require('fs')
     , rimraf  = require('rimraf')
     , mkdirp  = require('mkdirp')
@@ -9,7 +10,7 @@ const test    = require('tape')
 
     , cmd     = '"' + process.execPath + '" '
                 + path.join(__dirname, 'npmrc.js')
-    , homedir = path.join(tmpdir, 'npmrcs_test.' + process.pid)
+    , homedir = path.join(tmpdir, '.npmrcs_test.' + process.pid)
     , options = { env: xtend(process.env, { HOME: homedir }) }
     , npmrc   = path.join(homedir, '.npmrc')
     , npmrcs  = path.join(homedir, '.npmrcs')
@@ -30,6 +31,24 @@ test('blank slate', function (t) {
     t.ok(/Initialising/.test(stdout), 'got "initialising" msg')
     t.ok(/Creating .*\.npmrcs/.test(stdout), 'got "creating" msg')
     t.ok(/Activating .npmrc "default"/, 'got "activating" msg')
+    t.end()
+  })
+})
+
+test('change the registry url', function (t) {
+  exec(cmd + ' -r au', options, function (err, stdout, stderr) {
+    t.notOk(err, 'no error')
+    t.ok(fs.existsSync(npmrc), '.npmrc file exists')
+    t.ok(fs.existsSync(def), '.npmrc default file exists')
+    t.equal(fs.readFileSync(def, 'utf-8').split(os.EOL)[0], 'registry = http://registry.npmjs.org.au/', 'got the right registry url')
+    t.end()
+  })
+})
+
+test('error occurs when the wrong argument is supplied to -r', function (t) {
+  exec(cmd + ' -r foo', options, function (err, stdout, stderr) {
+    t.ok(err, 'error occured')
+    t.equal(err.code, 1, 'process exited with the right code')
     t.end()
   })
 })


### PR DESCRIPTION
Really sorry for all these commits but was having trouble integrating travis ci into the project.
Some of the test were failing on my windows machine:

``` shell
C:\Users\Ngene\dev\repos\npmrc (master)
λ npm test


> npmrc@1.0.1 test C:\Users\Ngene\dev\repos\npmrc
> tape test.js

TAP version 13
# blank slate
ok 1 no error
ok 2 no stderr
not ok 3 got "initialising" msg
  ---
    operator: ok
    expected: true
    actual:   false
  ...
not ok 4 got "creating" msg
  ---
    operator: ok
    expected: true
    actual:   false
  ...
ok 5 got "activating" msg
# change the registry url
ok 6 no error
ok 7 .npmrc file exists
ok 8 .npmrc default file exists
ok 9 got the right registry url
# error occurs when the wrong argument is supplied to -r
ok 10 error occured
ok 11 process exited with the right code
# cleanup
ok 12 null
# standard .npmrcs
ok 13 no error
ok 14 no stderr
not ok 15 got "initialising" msg
  ---
    operator: ok
    expected: true
    actual:   false
  ...
not ok 16 got "creating" msg
  ---
    operator: ok
    expected: true
    actual:   false
  ...
ok 17 got "activating" msg
ok 18 got "making default" msg
ok 19 got expected contents of .npmrc
ok 20 got expected contents of .npmrcs/default
ok 21 .npmrc is symlink
ok 22 .npmrc points to "default"
ok 23 only "default" in .npmrcs
# create noarg
ok 24 got error
ok 25 got correct exit code
ok 26 no stdout
not ok 27 got Usage
  ---
    operator: ok
    expected: true
    actual:   false
  ...
ok 28 got expected contents of .npmrc
ok 29 only "default" in .npmrcs
# create new config
ok 30 no error
ok 31 no stderr
ok 32 got "removing" msg
ok 33 got "activating" msg
ok 34 got expected contents of .npmrc
ok 35 got expected contents of .npmrcs/default
ok 36 got expected contents of .npmrcs/foobar
ok 37 .npmrc is symlink
ok 38 .npmrc points to "foobar"
ok 39 "default" and "foobar" in .npmrcs
# switch config
ok 40 no error
ok 41 no stderr
ok 42 got "removing" msg
ok 43 got "activating" msg
ok 44 got expected contents of .npmrc
ok 45 got expected contents of .npmrcs/default
ok 46 got expected contents of .npmrcs/foobar
ok 47 .npmrc is symlink
ok 48 .npmrc points to "foobar"
ok 49 "default" and "foobar" in .npmrcs
# list config
ok 50 no error
ok 51 no stderr
ok 52 got "available" msg
ok 53 listed "default"
ok 54 listed "foobar"
# switch to non-existent config
ok 55 got error
ok 56 got correct exit code
ok 57 no stdout
not ok 58 got expected error message
  ---
    operator: ok
    expected: true
    actual:   false
  ...
# partial matching start of npmrc
ok 59 no error
ok 60 no stderr
ok 61 got "activating" msg
# partial matching prefers full match over partial
ok 62 no error
ok 63 no error
ok 64 no stderr
ok 65 got "activating" msg
# partial matching prefers start of word match over partial match
ok 66 no error
ok 67 no error
ok 68 no error
ok 69 no stderr
ok 70 got "activating" msg
# partial matching can match any part of npmrc
ok 71 no error
ok 72 no stderr
ok 73 got "activating" msg
# partial matching matches alphabetically
ok 74 no error
ok 75 no error
ok 76 no error
ok 77 no stderr
ok 78 got "activating" msg
# cleanup
ok 79 null

1..79
# tests 79
# pass  73
# fail  6
```

especially with respect to testing the output of `stdout` and `stderr`  when executing the command.
I integrated travis to test the code on  a linux system and see the test pass.
The lastest [commit](https://github.com/ngenerio/npmrc/commit/60973642c1f31500110dfceaf305ac2159d491df) [passes](https://travis-ci.org/ngenerio/npmrc) successfully.
