### PR TITLE
ignore `.dotfiles`. Avoids unsightly `.DS_Store` files on OS X.

### DIFF
--- a/npmrc.js
+++ b/npmrc.js
@@ -58,7 +58,9 @@ function printNpmrcs () {
   fs.readlink(NPMRC, function (err, link) {
     link = link && path.basename(link)
     fs.readdirSync(NPMRC_STORE).forEach(function (npmrc) {
-      console.log(' %s %s', link == npmrc ? '*' : ' ', npmrc)
+      if (npmrc[0] !== '.') {
+        console.log(' %s %s', link == npmrc ? '*' : ' ', npmrc)
+      }
     })
   })
 }

--- a/test.js
+++ b/test.js
@@ -15,6 +15,7 @@ const test    = require('tape')
     , npmrc   = path.join(homedir, '.npmrc')
     , npmrcs  = path.join(homedir, '.npmrcs')
     , def     = path.join(homedir, '.npmrcs/default')
+    , dotfile = path.join(homedir, '.npmrcs/.dotfile')
 
 
 function cleanup (t) {
@@ -127,12 +128,14 @@ test('switch config', function (t) {
 
 
 test('list config', function (t) {
+  fs.writeFileSync(dotfile, '.dotfile', 'utf8')
   exec(cmd, options, function (err, stdout, stderr) {
     t.notOk(err, 'no error')
     t.equal(stderr, '', 'no stderr')
     t.ok(/Available npmrcs/.test(stdout), 'got "available" msg')
     t.ok((/\* default$/m).test(stdout), 'listed "default"')
     t.ok((/  foobar$/m).test(stdout), 'listed "foobar"')
+    t.notOk((/\.dotfile$/m).test(stdout), 'listed "dotfile"')
     t.end()
   })
 })


### PR DESCRIPTION
This sort of thing:
![screen shot 2014-10-25 at 4 50 57 pm](https://cloud.githubusercontent.com/assets/51505/4781099/28fdc82c-5c89-11e4-9b8c-91e27fd640de.png)
