### PR TITLE
fix help examples issue

### DIFF
--- a/npmrc.js
+++ b/npmrc.js
@@ -45,8 +45,8 @@ function printHelp () {
     + '  $ npmrc -c work\n\n'
     + '  # Switch betwen "work" and "default"\n'
     + '  $ npmrc work\n'
-    + '  $ npmrc default\n'
-    + '  # Use the European npm mirror'
+    + '  $ npmrc default\n\n'
+    + '  # Use the European npm mirror\n'
     + '  $ npmrc -r eu\n'
   )
   process.exit(1)


### PR DESCRIPTION
There is an issue in help example section and I fix it

Before

```
Example:

  # Creating and activating a new .npmrc called "work":
  $ npmrc -c work

  # Switch betwen "work" and "default"
  $ npmrc work
  $ npmrc default
  # Use the European npm mirror  $ npmrc -r eu
```

After

```
Example:

  # Creating and activating a new .npmrc called "work":
  $ npmrc -c work

  # Switch betwen "work" and "default"
  $ npmrc work
  $ npmrc default

  # Use the European npm mirror
  $ npmrc -r eu
```
