### PR TITLE
Fix symlink required administrator previledge on Windows

### DIFF
--- a/npmrc.js
+++ b/npmrc.js
@@ -95,7 +95,7 @@ function link (name) {
   }
 
   console.log('Activating .npmrc "%s"', path.basename(ln))
-  fs.symlinkSync(ln, NPMRC, 'file')
+  fs.symlinkSync(ln, NPMRC, 'junction')
 }
 
 // partial match npmrc names


### PR DESCRIPTION
Changing type to junction doesn't affect the other OS but on Windows it won't require administrator previledge